### PR TITLE
Simplest problem

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -17,7 +17,7 @@
 
   :cljsbuild {:builds
               [{:id "dev"
-                :source-paths ["src"]
+                :source-paths ["src" "test"]
 
                 ;; The presence of a :figwheel configuration here
                 ;; will cause figwheel to inject the figwheel client

--- a/src/edsger/substitution.cljs
+++ b/src/edsger/substitution.cljs
@@ -1,7 +1,5 @@
 (ns edsger.substitution)
 
-(def equiv :equiv)
-
 (defn new-value [pairs old-value]
   (some (fn [[old new]]
           (if (= old old-value) new))

--- a/src/edsger/substitution.cljs
+++ b/src/edsger/substitution.cljs
@@ -1,0 +1,54 @@
+(ns edsger.substitution)
+
+(def equiv :equiv)
+
+(defn new-value [pairs old-value]
+  (some (fn [[old new]]
+          (if (= old old-value) new))
+        pairs))
+
+(defn textual-substitution
+  "Performs textual substitution. `pairs` is expected to be a list of old values
+  and new values as pairs. e.g. `[[old0 new0] [old1 new1] ...]`. If `list`
+  contains elements that are `sequential?`, they will be recursively traversed. So any
+  substitution pair where `old*` is a `sequential?` will not have any effect."
+  [pairs list]
+  (map
+   (fn [old-value]
+     (if (sequential? old-value)
+       (textual-substitution pairs old-value)
+       (if-let [new-value (new-value pairs old-value)]
+         new-value
+         old-value)))
+   list))
+
+
+(defn highlight-elements [list]
+  "When passed a finite list, the output will conform to the following
+   constraints: The output will be a list of equal length to the input. Each
+   element will be a list containing exactly the elements of the input. Each
+   element will have a different element in the first position."
+  (let [size (count list)]
+    (take
+     size
+     (partition
+      size
+      1
+      (cycle list)))))
+
+(defn permutations-helper [left right]
+  (if (empty? right)
+    left
+    (map
+     (fn [elements]
+       (permutations-helper
+        (conj left (first elements))
+        (rest elements)))
+     (highlight-elements right))))
+
+(defn permutations
+  "Takes a `sequential?` and returns a list containing exactly all the
+   possible permutations of the passed in list."
+  [input]
+  (nth (permutations-helper '() input)
+       (dec (count input))))

--- a/src/edsger/substitution.cljs
+++ b/src/edsger/substitution.cljs
@@ -50,5 +50,6 @@
   "Takes a `sequential?` and returns a list containing exactly all the
    possible permutations of the passed in list."
   [input]
-  (nth (permutations-helper '() input)
+  (nth (iterate #(apply concat %)
+                (permutations-helper '() input))
        (dec (count input))))

--- a/src/edsger/substitution.cljs
+++ b/src/edsger/substitution.cljs
@@ -51,3 +51,24 @@
   (nth (iterate #(apply concat %)
                 (permutations-helper '() input))
        (dec (count input))))
+
+(defn generate-substitutions
+  "*IN PROGRESS*. Takes in a valid logic expression and returns a list of
+   single-variable subtitutions that can be performed based on that rule."
+  [expression]
+  (cond
+
+    (= :eqv (first expression))
+    (filter #(not (sequential? (first %)))
+            (permutations (rest expression)))))
+
+(defn verify-substitution
+  "All three arguments should be logic expressions in canonical form.
+   (Whatever we end up deciding that should be). This function should
+   return true if and only if the rule can be used to transform the
+   original expression to the resulting expression, else returns false."
+  [original-expression rule resulting-expression]
+  (some (fn [substitution]
+          (= resulting-expression
+             (textual-substitution [substitution] original-expression)))
+        (generate-substitutions rule)))

--- a/test/edsger/substitution_test.cljs
+++ b/test/edsger/substitution_test.cljs
@@ -14,3 +14,12 @@
 (deftest highlight-elements-three-elements
   (is (= '((1 2 3) (2 3 1) (3 1 2))
          (subst/highlight-elements '(1 2 3)))))
+
+(deftest verify-substitution-simple-success
+  (is (= true
+         (subst/verify-substitution [:a] [:eqv :a :b] [:b]))))
+
+(deftest verify-substitution-simple-failure
+  (is (= nil
+         (subst/verify-substitution [:a] [:eqv :a :b] [:c]))))
+

--- a/test/edsger/substitution_test.cljs
+++ b/test/edsger/substitution_test.cljs
@@ -2,9 +2,5 @@
   (:require [edsger.substitution :as subst]
             [clojure.test :as t :refer-macros [deftest is]]))
 
-(deftest i-should-fail
-  (is (= 1 0)))
 
-(deftest i-should-succeed
-  (is (= 1 1)))
 

--- a/test/edsger/substitution_test.cljs
+++ b/test/edsger/substitution_test.cljs
@@ -2,5 +2,15 @@
   (:require [edsger.substitution :as subst]
             [clojure.test :as t :refer-macros [deftest is]]))
 
+(deftest highlight-elements-empty-list
+  (is (= '() (subst/highlight-elements '()))))
 
+(deftest highlight-elements-one-element
+  (is (= '((1)) (subst/highlight-elements '(1)))))
 
+(deftest highlight-elements-two-elements
+  (is (= '((1 2) (2 1)) (subst/highlight-elements '(1 2)))))
+
+(deftest highlight-elements-three-elements
+  (is (= '((1 2 3) (2 3 1) (3 1 2))
+         (subst/highlight-elements '(1 2 3)))))

--- a/test/edsger/substitution_test.cljs
+++ b/test/edsger/substitution_test.cljs
@@ -1,0 +1,10 @@
+(ns edsger.substitution-test
+  (:require [edsger.substitution :as subst]
+            [clojure.test :as t :refer-macros [deftest is]]))
+
+(deftest i-should-fail
+  (is (= 1 0)))
+
+(deftest i-should-succeed
+  (is (= 1 1)))
+

--- a/test/edsger/test_runner.cljs
+++ b/test/edsger/test_runner.cljs
@@ -1,0 +1,11 @@
+(ns edsger.test-runner
+  (:require  [clojure.test :refer-macros [run-tests]]
+             [edsger.substitution-test]))
+
+;; This enables printing of some sort during tests?
+(enable-console-print!)
+
+(defn run-all-tests
+  []
+  (run-tests 'edsger.substitution-test))
+


### PR DESCRIPTION
This adds the `verify-substitution` function which can be used to verify _extremely_ trivial substitutions. (See namespace `edsger.substitution-test`for two examples of input and output.) Ultimately, the strategy used here might be the wrong one entirely.

This also adds some testing stuff, but that needs improvement so that they are easier to run.