### PR TITLE
Recursive matching

### DIFF
--- a/src/edsger/unification.cljs
+++ b/src/edsger/unification.cljs
@@ -24,6 +24,30 @@
                      (= start-binding end-binding))))
              end-matches))))
 
+
+(defn check-match-recursive [start-exp end-exp start-rule end-rule]
+  "Returns true when the given rules can be used to make the start-exp
+   equal to the end-exp."
+  (let [check (fn [s e]
+                (check-match s e start-rule end-rule))]
+      (or
+        (check start-exp end-exp)
+        (let
+            [result-list (map (fn [s e]
+                                {
+                                 :equal (= s e)
+                                 :match (if (and (list? s) (list? e))
+                                          (check-match-recursive s e
+                                                                 start-rule
+                                                                 end-rule)
+                                          (check s e))
+                                 })
+                              start-exp
+                              end-exp)]
+          (and
+           (some :match result-list)
+           (every? #(or (:match %) (:equal %)) result-list))))))
+
 ;; This file is currently only for playing around during development
 ;; but I think that we'll eventually have some useful functions here.
 

--- a/src/edsger/unification.cljs
+++ b/src/edsger/unification.cljs
@@ -1,11 +1,20 @@
 (ns edsger.unification
   (:require [cljs.core.logic :as logic :refer [binding-map]]))
 
+(defn wrap [exp]
+  (if-not (list? exp)
+    (list exp)
+    exp))
+
 (defn check-match [start-exp end-exp start-rule end-rule]
   "Returns true if start-exp can be matched with start-rule
    with the same bindings that cause end-exp to match end-rule."
-  (let [start-matches (binding-map start-exp start-rule)
-        end-matches (binding-map end-exp end-rule)]
+  (let [start-matches (binding-map
+                       (wrap start-exp)
+                       (wrap start-rule))
+        end-matches (binding-map
+                     (wrap end-exp)
+                     (wrap end-rule))]
     (and
      start-matches
      end-matches

--- a/test/edsger/unification_test.cljs
+++ b/test/edsger/unification_test.cljs
@@ -2,6 +2,14 @@
   (:require [edsger.unification :as u]
             [cljs.test :as t :refer-macros [deftest is] :include-macros true]))
 
+(deftest wrap-with-symbol
+  (is (= '(:a) (u/wrap :a))))
+
+(deftest wrap-with-list
+  (is (= '(2) (u/wrap '(2)))))
+
+;;-----------------------------------------------------
+
 (deftest a-test
   (is (true? (u/check-match '(:not (:equiv u (:or w y)))
                             '(:equiv (:not u) (:or w y))
@@ -40,7 +48,7 @@
                             '(true)))))
 
 (deftest constants-can-match
-  (is (true? (u/check-match '(:a) '(:b) '(:a) '(:b)))))
+  (is (true? (u/check-match ':a ':b ':a ':b))))
 
 (deftest constants-can-fail
-  (is (not (u/check-match '(:a) '(:c) '(:a) '(:b)))))
+  (is (not (u/check-match ':a ':c ':a ':b))))

--- a/test/edsger/unification_test.cljs
+++ b/test/edsger/unification_test.cljs
@@ -52,3 +52,33 @@
 
 (deftest constants-can-fail
   (is (not (u/check-match ':a ':c ':a ':b))))
+
+
+;; -------------------------------------------------------------
+(deftest non-recursive-case
+  (is (true? (u/check-match-recursive
+              '(:not (:equiv u (:or w y)))
+              '(:equiv (:not u) (:or w y))
+              '(:not (:equiv ?a ?b))
+              '(:equiv (:not ?a) ?b)))))
+
+(deftest simple-recursive-case
+  (is (true? (u/check-match-recursive
+              '(:and p (:equiv true true))
+              '(:and p true)
+              '(:equiv ?q ?q)
+              '(true)))))
+
+(deftest rule-applies-but-not-actually-equal
+  (is (not (u/check-match-recursive
+            '(:and p (:equiv true true))
+            '(:or p true)
+            '(:equiv ?q ?q)
+            '(true)))))
+
+(deftest rule-applies-but-not-actually-equal-v2
+  (is (not (u/check-match-recursive
+            '(:and p (:equiv true true) false)
+            '(:and p true true)
+            '(:equiv ?q ?q)
+            '(true)))))


### PR DESCRIPTION
This PR modifies `check-match` slightly and adds `check-match-recursive`. This new function checks to see if we can use a substitution to make two expressions equal, and will recursively explore the expressions to find the spot where the substitution must occur.

If we merge this, we should probably merge the `unification` branch into `dev`.