### PR TITLE
Make parser whitespace agnostic

### DIFF
--- a/src/edsger/parsing.cljs
+++ b/src/edsger/parsing.cljs
@@ -6,13 +6,14 @@
 ;; operators. Currently requires expressions to be fully parenthesized.
 (insta/defparser
   infix-cfg
-  (str "top-level   = boolean | variable | unary-expr | binary-expr;"
+  (str "top-level   = <whitespace> (boolean | variable | unary-expr | binary-expr) <whitespace>;"
+       "whitespace   = #'\\s*';" ;; https://docs.oracle.com/javase/tutorial/essential/regex/pre_char_classes.html
        "boolean     = 'true' | 'false';"
        "variable    = #'[a-zA-Z]';" ;; we only support single-character variables
        "unary-op    = '¬';"
-       "unary-expr  = unary-op (<' '> | epsilon) bottom;"
+       "unary-expr  = unary-op <whitespace> bottom;"
        "bottom      = boolean | variable | <'('> top-level <')'>;"
-       "binary-expr = bottom <' '> binary-op <' '> bottom;"
+       "binary-expr = bottom <whitespace> binary-op <whitespace> bottom;"
        "binary-op   = '∨' | '∧' | '≡'| '⇒';"))
 
 (def ^:private operator-map

--- a/test/edsger/parsing_test.cljs
+++ b/test/edsger/parsing_test.cljs
@@ -88,6 +88,38 @@
 (deftest parse_bad
   (is (nil? (p/parse "(:or a)"))))
 
+(deftest parse_binary-op_whitespace-agnostic
+  (are [expr] (= (p/parse expr) [:and 'p 'r])
+    "p∧r"
+    "p ∧ r"
+    " p ∧ r "
+    " p∧ r"
+    "  p∧ r"
+    "p∧ r    "))
+
+(deftest parse_simple_whitespace-agnostic
+  (are [form1 form2] (and (not (nil? form1))
+                          (not (nil? form2))
+                          (= (p/parse form1) (p/parse form2)))
+    "true" " true\t"
+    "a" "a\r\n"
+    "false" "   false  \t  "))
+
+(deftest parse_unary-op_whitespace-agnostic
+  (are [expr] (= (p/parse expr) [:not 'p])
+    "¬p"
+    "¬ p"
+    " ¬p"
+    "¬p "
+    " ¬\tp\n"))
+
+(deftest parse_nested_whitespace-agnostic
+  (are [expr] (= (p/parse expr) [:or
+                                 [:implies 'a false]
+                                 [:not [:and 't 'u]]])
+    "(a ⇒ false) ∨ (¬ (t ∧ u))"
+    "(a⇒false)∨(¬(t∧u))"
+    " ( a ⇒ false ) ∨ ( ¬ ( t ∧ u ) ) "))
 
 ;; ==== Tests for `rulify`
 


### PR DESCRIPTION
Fixes #21 

I've added some tests to demonstrate that this is indeed fixed.