### PR TITLE
Indicate where parsing failed

### DIFF
--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -44,7 +44,7 @@
               <form>
                 <div class="form-group row">
                   <label for="inputExp" class="col-sm-2 col-form-label">Expression</label>
-                  <div class="col-sm-10">
+                  <div class="col">
                     <input type="text" class="form-control ex" placeholder="Type an expression (e.x. p ∧ q)">
                   </div>
                 </div>
@@ -60,7 +60,7 @@
                 </div>
                 <div class="form-group row">
                   <label for="inputExp" class="col-sm-2 col-form-label">Expression</label>
-                  <div class="col-sm-10">
+                  <div class="col">
                     <input type="text" class="form-control ex" placeholder="Type an expression (e.x. q ∧ p)">
                   </div>
                 </div>

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -42,23 +42,23 @@
           <div class="row">
             <div class="col-12 col-lg-12">
               <form>
-                <div class="form-group row">
+                <div class="form-group row exp-box">
                   <label for="inputExp" class="col-sm-2 col-form-label">Expression</label>
                   <div class="col">
                     <input type="text" class="form-control ex" placeholder="Type an expression (e.x. p ∧ q)">
                   </div>
                 </div>
-                <div class="form-group row">
+                <div class="form-group row rule-box">
                   <label for="inputRule" class="col-sm-2 col-form-label">Rule</label>
-                  <div class="col">
+                  <div class="col rule-box-left">
                     <input type="text" class="form-control rule" placeholder="Left-hand side of rule">
                   </div>
                   <span> ≡ </span>
-                  <div class="col">
+                  <div class="col rule-box-right">
                     <input type="text" class="form-control rule" placeholder="Right-hand side of rule">
                   </div>
                 </div>
-                <div class="form-group row">
+                <div class="form-group row exp-box">
                   <label for="inputExp" class="col-sm-2 col-form-label">Expression</label>
                   <div class="col">
                     <input type="text" class="form-control ex" placeholder="Type an expression (e.x. q ∧ p)">

--- a/src/edsger/core.cljs
+++ b/src/edsger/core.cljs
@@ -36,6 +36,10 @@
   [html-str]
   (.createContextualFragment (.createRange js/document) html-str))
 
+(defn- remove-elems-by-class
+  "Removes all elements from dom with the given class"
+  [class]
+  (dorun (map #(gdom/removeNode %) (iArrayLike-to-cljs-list (gdom/getElementsByClass class)))))
 
 
 ;; UI and handlers ===================
@@ -115,6 +119,7 @@
                                                           (nth exps 1)
                                                           (nth rules 0)
                                                           (nth rules 1))))]
+    (remove-elems-by-class "alert-danger")
     (when non-empty-input
       (if (some not-empty [exp-parse-err rule-parse-err])
         (do (show-exp-parse-err exp-parse-err)

--- a/src/edsger/core.cljs
+++ b/src/edsger/core.cljs
@@ -119,15 +119,12 @@
 
 ;; Top-level handler / listener ===================
 
-;; TODO: simplify this
 (defn window-load-handler
   "Top-level load handler"
   []
   (validate-click-listener (by-id "validate"))
-  (copy-click-listener (by-id "not") "not")
-  (copy-click-listener (by-id "and") "and")
-  (copy-click-listener (by-id "or") "or")
-  (copy-click-listener (by-id "impli") "impli")
-  (copy-click-listener (by-id "equiv") "equiv"))
+  (dorun
+   (map #(copy-click-listener (by-id %) %)
+        ["not" "and" "or" "impli" "equiv"])))
 
 (events/listen js/window "load" window-load-handler)

--- a/src/edsger/core.cljs
+++ b/src/edsger/core.cljs
@@ -66,12 +66,17 @@
        "</div>"))
 
 (defn- merge-val
+  "Takes a map looking `{:curr-id # :locations []}` and a number.
+   Returns a new map looking `{:curr-id (inc #) :locations []}`.
+   If val is nil, (inc #) is added to the `:locations` vector"
   [curr-map val]
   (let [curr-map (update curr-map :curr-id inc)
         curr-id (:curr-id curr-map)]
     (if (nil? val) (update-in curr-map [:locations] #(conj % curr-id)) curr-map)))
 
 (defn- show-exp-parse-err
+  "Takes a vector of indices and attach error message elements
+   to corresponding exp input box"
   [err-id-vec]
   (let [exp-boxes (iArrayLike-to-cljs-list (gdom/getElementsByClass "exp-box"))]
     (dorun
@@ -82,6 +87,8 @@
       err-id-vec))))
 
 (defn- show-rule-parse-err
+  "Takes a vector of indices and attach error message elements
+   to corresponding rule input box"
   [err-id-vec]
   (let [rule-cols (map #(gdom/getParentElement %)
                        (iArrayLike-to-cljs-list (gdom/getElementsByClass "rule")))]

--- a/src/edsger/core.cljs
+++ b/src/edsger/core.cljs
@@ -95,10 +95,11 @@
 (defn validate-handler
   "Performs the validation based on the values typed by users"
   [evt]
-  (let [ex-elems (gdom/getElementsByClass "ex") ;; `iArrayLike` type
-        rule-elems (gdom/getElementsByClass "rule")
-        exps (map #(parsing/parse (.-value %)) (iArrayLike-to-cljs-list ex-elems))
-        vanilla-rules (map #(parsing/parse (.-value %)) (iArrayLike-to-cljs-list rule-elems))
+  (let [exp-str-li (map #(.-value %) (iArrayLike-to-cljs-list (gdom/getElementsByClass "ex")))
+        rule-str-li (map #(.-value %) (iArrayLike-to-cljs-list (gdom/getElementsByClass "rule")))
+        non-empty-input (every? #(not= "" %) (concat exp-str-li rule-str-li))
+        exps (map #(parsing/parse %) exp-str-li)
+        vanilla-rules (map #(parsing/parse %) rule-str-li)
         rules (map #(parsing/rulify %) vanilla-rules)
         ;; vector of indices where parsing err occurred (e.g., [0, 3])
         exp-parse-err (:locations (reduce merge-val {:curr-id -1 :locations []} exps))
@@ -107,9 +108,11 @@
                                                           (nth exps 1)
                                                           (nth rules 0)
                                                           (nth rules 1))))]
-    (when-not (empty? exp-parse-err) (show-exp-parse-err exp-parse-err))
-    (when-not (empty? rule-parse-err) (show-rule-parse-err rule-parse-err))
-    (.alert js/window result-str)))
+    (when non-empty-input
+      (cond
+        (not (empty? exp-parse-err)) (show-exp-parse-err exp-parse-err)
+        (not (empty? rule-parse-err)) (show-rule-parse-err rule-parse-err)
+        :else (.alert js/window result-str)))))
 
 (defn validate-click-listener
   [elem]

--- a/src/edsger/core.cljs
+++ b/src/edsger/core.cljs
@@ -116,10 +116,10 @@
                                                           (nth rules 0)
                                                           (nth rules 1))))]
     (when non-empty-input
-      (cond
-        (not (empty? exp-parse-err)) (show-exp-parse-err exp-parse-err)
-        (not (empty? rule-parse-err)) (show-rule-parse-err rule-parse-err)
-        :else (.alert js/window result-str)))))
+      (if (some not-empty [exp-parse-err rule-parse-err])
+        (do (show-exp-parse-err exp-parse-err)
+            (show-rule-parse-err rule-parse-err))
+        (.alert js/window result-str)))))
 
 (defn validate-click-listener
   [elem]


### PR DESCRIPTION
Fix #17 
* Show a popup message indicating where parsing failed (they look ugly but that's a future task)
* `Validate` button doesn't work if there's an empty input box